### PR TITLE
lint fixes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -436,15 +436,9 @@ fn process_file(
 
             // Iterate through the keys of the JSON object and remove any field that is not in the allowed_fields list
             if let Value::Object(ref mut map) = data {
-                let keys_to_remove: Vec<String> = map
-                    .keys()
-                    .filter(|key| !allowed_fields.contains(&key.as_str()))
-                    .cloned()
-                    .collect();
-                for key in keys_to_remove {
-                    map.remove(&key);
+                map.retain(|key, _| allowed_fields.contains(&key.as_str()));
                 }
-            }
+            
         }
 
         serde_json::to_writer(&mut writer, &data)?;


### PR DESCRIPTION
`cargo clippy` returns clean.
`cargo clippy -- -Wclippy::pedantic' still returns some warnings. (This isn't bad in of itself since pedantic has false positives, but it would be best to either avoid relevant errors. IF they are indeed working as intended we could suppress them)

To do any further refactoring, we would need tests, and for integration tests some test vectors could be useful.